### PR TITLE
Extract Docker build steps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,9 @@ USER elife
 ENV PROJECT_FOLDER=/srv/hypothesis-dummy
 RUN mkdir ${PROJECT_FOLDER}
 WORKDIR ${PROJECT_FOLDER}
-COPY --chown=elife:elife composer.json composer.lock ${PROJECT_FOLDER}
+COPY --chown=elife:elife composer.json composer.lock ${PROJECT_FOLDER}/
 RUN composer install --classmap-authoritative --no-dev
-COPY --chown=elife:elife . ${PROJECT_FOLDER}
+COPY --chown=elife:elife . ${PROJECT_FOLDER}/
 
 USER www-data
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 FROM elifesciences/php_cli
 
 USER elife
-RUN mkdir /srv/hypothesis-dummy
-WORKDIR /srv/hypothesis-dummy
-COPY --chown=elife:elife composer.json composer.lock /srv/hypothesis-dummy/
+ENV PROJECT_FOLDER=/srv/hypothesis-dummy
+RUN mkdir ${PROJECT_FOLDER}
+WORKDIR ${PROJECT_FOLDER}
+COPY --chown=elife:elife composer.json composer.lock ${PROJECT_FOLDER}
 RUN composer install --classmap-authoritative --no-dev
-COPY --chown=elife:elife . /srv/hypothesis-dummy/
+COPY --chown=elife:elife . ${PROJECT_FOLDER}
 
 USER www-data
 EXPOSE 8080

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -11,7 +11,7 @@ COPY --from=proofreader --chown=elife:elife /srv/proofreader-php /srv/proofreade
 RUN ln -s /srv/proofreader-php/bin/proofreader /srv/bin/proofreader
 
 RUN composer install
-COPY --chown=elife .php_cs project_tests.sh smoke_tests.sh ${PROJECT_FOLDER}
+COPY --chown=elife .php_cs project_tests.sh smoke_tests.sh ${PROJECT_FOLDER}/
 
 USER www-data
 CMD ["/bin/bash", "project_tests.sh"]

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -11,7 +11,7 @@ COPY --from=proofreader --chown=elife:elife /srv/proofreader-php /srv/proofreade
 RUN ln -s /srv/proofreader-php/bin/proofreader /srv/bin/proofreader
 
 RUN composer install
-COPY --chown=elife .php_cs project_tests.sh smoke_tests.sh /srv/hypothesis-dummy/
+COPY --chown=elife .php_cs project_tests.sh smoke_tests.sh ${PROJECT_FOLDER}
 
 USER www-data
 CMD ["/bin/bash", "project_tests.sh"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,9 +13,7 @@ elifeLibrary {
 
     stage 'Project tests', {
         dockerBuildCi 'hypothesis-dummy', commit
-        // TODO: if we could use $PROJECT_FOLDER provided by the image,
-        // we may avoid passing `folder`?
-        dockerProjectTests 'hypothesis-dummy', commit, '/srv/hypothesis-dummy'
+        dockerProjectTests 'hypothesis-dummy', commit
     }
 
     elifeMainlineOnly {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,10 +12,10 @@ elifeLibrary {
     }
 
     stage 'Project tests', {
-        // TODO: steps to be extracted in elife-jenkins-workflow-libs
-        sh "docker build -f Dockerfile.ci -t elifesciences/hypothesis-dummy_ci:${commit} --build-arg commit=${commit} ."
-        sh "chmod 777 build/ && docker run -v \$(pwd)/build:/srv/hypothesis-dummy/build elifesciences/hypothesis-dummy_ci:${commit}"
-        step([$class: "JUnitResultArchiver", testResults: 'build/phpunit.xml'])
+        dockerBuildCi 'hypothesis-dummy', commit
+        // TODO: if we could use $PROJECT_FOLDER provided by the image,
+        // we may avoid passing `folder`?
+        dockerProjectTests 'hypothesis-dummy', commit, '/srv/hypothesis-dummy'
     }
 
     elifeMainlineOnly {


### PR DESCRIPTION
So that they are reusable inside other library (or even non-library) projects.