### PR TITLE
Create build/ folder in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM elifesciences/php_cli
+FROM elifesciences/php_cli:22434ef5bda09326d4c9347de7d8c2f1610a0b83
 
 USER elife
 ENV PROJECT_FOLDER=/srv/hypothesis-dummy

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -13,5 +13,8 @@ RUN ln -s /srv/proofreader-php/bin/proofreader /srv/bin/proofreader
 RUN composer install
 COPY --chown=elife .php_cs project_tests.sh smoke_tests.sh ${PROJECT_FOLDER}/
 
+USER root
+RUN create-build-folder
+
 USER www-data
 CMD ["/bin/bash", "project_tests.sh"]

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -2,8 +2,10 @@ ARG commit=latest
 FROM elifesciences/proofreader-php:latest AS proofreader
 FROM elifesciences/hypothesis-dummy:${commit}
 
-# extract into another image and put here with multi-stage build
 USER root
+RUN create-build-folder
+
+# extract into another image and put here with multi-stage build
 RUN git clone https://github.com/asm89/smoke.sh /opt/smoke.sh
 
 USER elife
@@ -12,9 +14,6 @@ RUN ln -s /srv/proofreader-php/bin/proofreader /srv/bin/proofreader
 
 RUN composer install
 COPY --chown=elife .php_cs project_tests.sh smoke_tests.sh ${PROJECT_FOLDER}/
-
-USER root
-RUN create-build-folder
 
 USER www-data
 CMD ["/bin/bash", "project_tests.sh"]


### PR DESCRIPTION
Rather than mounting it from the outside. This goes in the direction of running the container and then `docker cp` on it from the container filesystem to the Jenkins node, before cleaning all the containers up.

Depends on https://github.com/elifesciences/elife-base-images/pull/16